### PR TITLE
Bump third-party Gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,21 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "saturday"
+    time: "08:00"
+    timezone: "America/Chicago"
 - package-ecosystem: "gradle"
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "saturday"
+    time: "08:00"
+    timezone: "America/Chicago"
+  open-pull-requests-limit: 20
 - package-ecosystem: "docker"
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "saturday"
+    time: "08:00"
+    timezone: "America/Chicago"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 cohort = "2.8.3"
 detekt = "2.0.0-alpha.2"
-fabrikt = "26.1.0"
-jooq = "3.20.11"
+fabrikt = "26.2.2"
+jooq = "3.21.1"
 koin = "4.2.0"
-kover = "0.9.7"
+kover = "0.9.8"
 kotest = "6.1.11"
 kotlin = "2.3.20"
 kotlin-logging = "8.0.01"
 kotlin-result = "2.3.1"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
-ktor = "3.4.1"
-lettuce = "7.5.0.RELEASE"
+ktor = "3.4.2"
+lettuce = "7.5.1.RELEASE"
 logback = "1.5.32"
 micrometer = "1.16.4"
-netty = "4.2.10.Final"
+netty = "4.2.12.Final"
 postgresql = "42.7.10" # Used in code generation tasks only
 r2dbc-pool = "1.0.2.RELEASE"
 r2dbc-postgresql = "1.1.1.RELEASE"
@@ -26,7 +26,7 @@ cohort-ktor = { module = "com.sksamuel.cohort:cohort-ktor", version.ref = "cohor
 cohort-lettuce = { module = "com.sksamuel.cohort:cohort-lettuce", version.ref = "cohort" }
 cohort-logback = { module = "com.sksamuel.cohort:cohort-logback", version.ref = "cohort" }
 cohort-micrometer = { module = "com.sksamuel.cohort:cohort-micrometer", version.ref = "cohort" }
-fabrikt = { module = "com.cjbooms:fabrikt", version.ref = "fabrikt" }
+fabrikt = { module = "io.fabrikt:fabrikt", version.ref = "fabrikt" }
 jooq-kotlin = { module = "org.jooq:jooq-kotlin", version.ref = "jooq" }
 jooq-kotlin-coroutines = { module = "org.jooq:jooq-kotlin-coroutines", version.ref = "jooq" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }

--- a/src/generated/kotlin/com/example/generated/db/DefaultCatalog.kt
+++ b/src/generated/kotlin/com/example/generated/db/DefaultCatalog.kt
@@ -34,10 +34,10 @@ open class DefaultCatalog : CatalogImpl("") {
     )
 
     /**
-     * A reference to the 3.20 minor release of the code generator. If this
+     * A reference to the 3.21 minor release of the code generator. If this
      * doesn't compile, it's because the runtime library uses an older minor
-     * release, namely: 3.20. You can turn off the generation of this reference
+     * release, namely: 3.21. You can turn off the generation of this reference
      * by specifying /configuration/generator/generate/jooqVersionReference
      */
-    private val REQUIRE_RUNTIME_JOOQ_VERSION = Constants.VERSION_3_20
+    private val REQUIRE_RUNTIME_JOOQ_VERSION = Constants.VERSION_3_21
 }

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV1.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV1.kt
@@ -25,7 +25,7 @@ open class UuidGenerateV1 : AbstractRoutine<UUID>("uuid_generate_v1", Public.PUB
         /**
          * The parameter <code>public.uuid_generate_v1.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV1mc.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV1mc.kt
@@ -25,7 +25,7 @@ open class UuidGenerateV1mc : AbstractRoutine<UUID>("uuid_generate_v1mc", Public
         /**
          * The parameter <code>public.uuid_generate_v1mc.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV3.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV3.kt
@@ -26,17 +26,17 @@ open class UuidGenerateV3 : AbstractRoutine<UUID>("uuid_generate_v3", Public.PUB
         /**
          * The parameter <code>public.uuid_generate_v3.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
 
         /**
          * The parameter <code>public.uuid_generate_v3.namespace</code>.
          */
-        val NAMESPACE: Parameter<UUID?> = Internal.createParameter("namespace", SQLDataType.UUID, false, false)
+        val NAMESPACE: Parameter<UUID?> = Internal.createParameter("namespace", SQLDataType.UUID, false)
 
         /**
          * The parameter <code>public.uuid_generate_v3.name</code>.
          */
-        val NAME: Parameter<String?> = Internal.createParameter("name", SQLDataType.CLOB, false, false)
+        val NAME: Parameter<String?> = Internal.createParameter("name", SQLDataType.CLOB, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV4.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV4.kt
@@ -25,7 +25,7 @@ open class UuidGenerateV4 : AbstractRoutine<UUID>("uuid_generate_v4", Public.PUB
         /**
          * The parameter <code>public.uuid_generate_v4.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV5.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidGenerateV5.kt
@@ -26,17 +26,17 @@ open class UuidGenerateV5 : AbstractRoutine<UUID>("uuid_generate_v5", Public.PUB
         /**
          * The parameter <code>public.uuid_generate_v5.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
 
         /**
          * The parameter <code>public.uuid_generate_v5.namespace</code>.
          */
-        val NAMESPACE: Parameter<UUID?> = Internal.createParameter("namespace", SQLDataType.UUID, false, false)
+        val NAMESPACE: Parameter<UUID?> = Internal.createParameter("namespace", SQLDataType.UUID, false)
 
         /**
          * The parameter <code>public.uuid_generate_v5.name</code>.
          */
-        val NAME: Parameter<String?> = Internal.createParameter("name", SQLDataType.CLOB, false, false)
+        val NAME: Parameter<String?> = Internal.createParameter("name", SQLDataType.CLOB, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidNil.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidNil.kt
@@ -25,7 +25,7 @@ open class UuidNil : AbstractRoutine<UUID>("uuid_nil", Public.PUBLIC, DSL.commen
         /**
          * The parameter <code>public.uuid_nil.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidNsDns.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidNsDns.kt
@@ -25,7 +25,7 @@ open class UuidNsDns : AbstractRoutine<UUID>("uuid_ns_dns", Public.PUBLIC, DSL.c
         /**
          * The parameter <code>public.uuid_ns_dns.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidNsOid.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidNsOid.kt
@@ -25,7 +25,7 @@ open class UuidNsOid : AbstractRoutine<UUID>("uuid_ns_oid", Public.PUBLIC, DSL.c
         /**
          * The parameter <code>public.uuid_ns_oid.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidNsUrl.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidNsUrl.kt
@@ -25,7 +25,7 @@ open class UuidNsUrl : AbstractRoutine<UUID>("uuid_ns_url", Public.PUBLIC, DSL.c
         /**
          * The parameter <code>public.uuid_ns_url.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/routines/UuidNsX500.kt
+++ b/src/generated/kotlin/com/example/generated/db/routines/UuidNsX500.kt
@@ -25,7 +25,7 @@ open class UuidNsX500 : AbstractRoutine<UUID>("uuid_ns_x500", Public.PUBLIC, DSL
         /**
          * The parameter <code>public.uuid_ns_x500.RETURN_VALUE</code>.
          */
-        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false, false)
+        val RETURN_VALUE: Parameter<UUID?> = Internal.createParameter("RETURN_VALUE", SQLDataType.UUID, false)
     }
 
     init {

--- a/src/generated/kotlin/com/example/generated/db/tables/SchemaMigrations.kt
+++ b/src/generated/kotlin/com/example/generated/db/tables/SchemaMigrations.kt
@@ -20,13 +20,14 @@ import org.jooq.QueryPart
 import org.jooq.Record
 import org.jooq.SQL
 import org.jooq.Schema
-import org.jooq.Select
 import org.jooq.Stringly
 import org.jooq.Table
 import org.jooq.TableField
+import org.jooq.TableLike
 import org.jooq.TableOptions
 import org.jooq.UniqueKey
 import org.jooq.impl.DSL
+import org.jooq.impl.Internal
 import org.jooq.impl.SQLDataType
 import org.jooq.impl.TableImpl
 
@@ -115,7 +116,7 @@ open class SchemaMigrations(
     /**
      * Create an inline derived table from this table
      */
-    override fun where(condition: Condition?): SchemaMigrations = SchemaMigrations(qualifiedName, if (aliased()) this else null, condition)
+    override fun where(condition: Condition?): SchemaMigrations = SchemaMigrations(qualifiedName, if (aliased()) this else null, Internal.condition(this, condition))
 
     /**
      * Create an inline derived table from this table
@@ -155,10 +156,10 @@ open class SchemaMigrations(
     /**
      * Create an inline derived table from this table
      */
-    override fun whereExists(select: Select<*>): SchemaMigrations = where(DSL.exists(select))
+    override fun whereExists(select: TableLike<*>): SchemaMigrations = where(DSL.exists(select))
 
     /**
      * Create an inline derived table from this table
      */
-    override fun whereNotExists(select: Select<*>): SchemaMigrations = where(DSL.notExists(select))
+    override fun whereNotExists(select: TableLike<*>): SchemaMigrations = where(DSL.notExists(select))
 }

--- a/src/generated/kotlin/com/example/generated/db/tables/Todo.kt
+++ b/src/generated/kotlin/com/example/generated/db/tables/Todo.kt
@@ -26,13 +26,14 @@ import org.jooq.QueryPart
 import org.jooq.Record
 import org.jooq.SQL
 import org.jooq.Schema
-import org.jooq.Select
 import org.jooq.Stringly
 import org.jooq.Table
 import org.jooq.TableField
+import org.jooq.TableLike
 import org.jooq.TableOptions
 import org.jooq.UniqueKey
 import org.jooq.impl.DSL
+import org.jooq.impl.Internal
 import org.jooq.impl.SQLDataType
 import org.jooq.impl.TableImpl
 
@@ -153,7 +154,7 @@ open class Todo(
     /**
      * Create an inline derived table from this table
      */
-    override fun where(condition: Condition?): Todo = Todo(qualifiedName, if (aliased()) this else null, condition)
+    override fun where(condition: Condition?): Todo = Todo(qualifiedName, if (aliased()) this else null, Internal.condition(this, condition))
 
     /**
      * Create an inline derived table from this table
@@ -193,10 +194,10 @@ open class Todo(
     /**
      * Create an inline derived table from this table
      */
-    override fun whereExists(select: Select<*>): Todo = where(DSL.exists(select))
+    override fun whereExists(select: TableLike<*>): Todo = where(DSL.exists(select))
 
     /**
      * Create an inline derived table from this table
      */
-    override fun whereNotExists(select: Select<*>): Todo = where(DSL.notExists(select))
+    override fun whereNotExists(select: TableLike<*>): Todo = where(DSL.notExists(select))
 }

--- a/src/generated/kotlin/com/example/generated/db/tables/records/TodoRecord.kt
+++ b/src/generated/kotlin/com/example/generated/db/tables/records/TodoRecord.kt
@@ -20,26 +20,44 @@ import org.jooq.impl.UpdatableRecordImpl
 @Suppress("warnings")
 open class TodoRecord() : UpdatableRecordImpl<TodoRecord>(Todo.TODO) {
 
+    /**
+     * The unique id (Primary Key) for this table.
+     */
     open var id: UUID?
         set(value): Unit = set(0, value)
         get(): UUID? = get(0) as UUID?
 
+    /**
+     * The name for the todo record.
+     */
     open var name: String?
         set(value): Unit = set(1, value)
         get(): String? = get(1) as String?
 
+    /**
+     * The time the todo was marked as completed.
+     */
     open var completedAt: Instant?
         set(value): Unit = set(2, value)
         get(): Instant? = get(2) as Instant?
 
+    /**
+     * The date / time that this record was created.
+     */
     open var createdAt: Instant?
         set(value): Unit = set(3, value)
         get(): Instant? = get(3) as Instant?
 
+    /**
+     * The date / time that this record was last updated.
+     */
     open var updatedAt: Instant?
         set(value): Unit = set(4, value)
         get(): Instant? = get(4) as Instant?
 
+    /**
+     * The id of the user who owns this todo item.
+     */
     open var userId: String?
         set(value): Unit = set(5, value)
         get(): String? = get(5) as String?


### PR DESCRIPTION
- fabrikt: 26.1.0 → 26.2.2 (group ID changed to io.fabrikt:fabrikt)
- jooq: 3.20.11 → 3.21.1 (includes regenerated jOOQ classes)
- kover: 0.9.7 → 0.9.8
- ktor: 3.4.1 → 3.4.2
- lettuce: 7.5.0.RELEASE → 7.5.1.RELEASE
- netty: 4.2.10.Final → 4.2.12.Final
- dependabot: add schedule day/time/timezone and raise gradle PR limit